### PR TITLE
define java main class for the cli

### DIFF
--- a/htmlchecker-cli/build.gradle
+++ b/htmlchecker-cli/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'application'
+
 dependencies {
     implementation project(':htmlchecker-core')
     implementation 'com.selesse:jxlint-cli:2.2.0'
@@ -5,6 +7,19 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.hamcrest:hamcrest-core:1.3'
     testImplementation 'org.assertj:assertj-core:3.6.2'
+}
+
+String appMainClass = 'fr.jmini.htmlchecker.cli.Main'
+application {
+    mainClass = appMainClass
+}
+
+jar {
+  manifest {
+    attributes(
+      'Main-Class': appMainClass
+    )
+  }
 }
 
 publishing {


### PR DESCRIPTION
The cli jar can not be started with `java -jar`

```
no main manifest attribute, in htmlchecker-cli-1.2.3.jar
```

Using jbang: `jbang run fr.jmini.htmlchecker:htmlchecker-cli:1.2.3`:

```
[jbang] [ERROR] no main class deduced, specified nor found in a manifest
[jbang] Run with --verbose for more details
```

---

With this PR the main class will be set in the `MANIFEST.MF`